### PR TITLE
Injecting ethers provider into LoginStrategy

### DIFF
--- a/examples/server/express/package-lock.json
+++ b/examples/server/express/package-lock.json
@@ -13,6 +13,11 @@
         "negotiator": "0.6.2"
       }
     },
+    "aes-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-3.0.0.tgz",
+      "integrity": "sha1-4h3xCtbCBTKVvLuNq0Cwnb6ofk0="
+    },
     "array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -25,6 +30,11 @@
       "requires": {
         "safe-buffer": "5.1.2"
       }
+    },
+    "bn.js": {
+      "version": "4.11.9",
+      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
+      "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw=="
     },
     "body-parser": {
       "version": "1.19.0",
@@ -42,6 +52,11 @@
         "raw-body": "2.4.0",
         "type-is": "~1.6.17"
       }
+    },
+    "brorand": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
+      "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8="
     },
     "buffer-equal-constant-time": {
       "version": "1.0.1",
@@ -107,6 +122,20 @@
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
       "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
+    "elliptic": {
+      "version": "6.5.3",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.3.tgz",
+      "integrity": "sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==",
+      "requires": {
+        "bn.js": "^4.4.0",
+        "brorand": "^1.0.1",
+        "hash.js": "^1.0.0",
+        "hmac-drbg": "^1.0.0",
+        "inherits": "^2.0.1",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.0"
+      }
+    },
     "encodeurl": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -121,6 +150,22 @@
       "version": "1.8.1",
       "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
       "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
+    },
+    "ethers": {
+      "version": "4.0.48",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-4.0.48.tgz",
+      "integrity": "sha512-sZD5K8H28dOrcidzx9f8KYh8083n5BexIO3+SbE4jK83L85FxtpXZBCQdXb8gkg+7sBqomcLhhkU7UHL+F7I2g==",
+      "requires": {
+        "aes-js": "3.0.0",
+        "bn.js": "^4.4.0",
+        "elliptic": "6.5.3",
+        "hash.js": "1.1.3",
+        "js-sha3": "0.5.7",
+        "scrypt-js": "2.0.4",
+        "setimmediate": "1.0.4",
+        "uuid": "2.0.1",
+        "xmlhttprequest": "1.8.0"
+      }
     },
     "express": {
       "version": "4.17.1",
@@ -183,6 +228,25 @@
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
       "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
+    "hash.js": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
+      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "requires": {
+        "inherits": "^2.0.3",
+        "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "hmac-drbg": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
+      "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
+      "requires": {
+        "hash.js": "^1.0.3",
+        "minimalistic-assert": "^1.0.0",
+        "minimalistic-crypto-utils": "^1.0.1"
+      }
+    },
     "http-errors": {
       "version": "1.7.2",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.7.2.tgz",
@@ -212,6 +276,11 @@
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
       "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g=="
+    },
+    "js-sha3": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/js-sha3/-/js-sha3-0.5.7.tgz",
+      "integrity": "sha1-DU/9gALVMzqrr0oj7tL2N0yfKOc="
     },
     "jsonwebtoken": {
       "version": "8.5.1",
@@ -323,6 +392,16 @@
       "requires": {
         "mime-db": "1.44.0"
       }
+    },
+    "minimalistic-assert": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-assert/-/minimalistic-assert-1.0.1.tgz",
+      "integrity": "sha512-UtJcAD4yEaGtjPezWuO9wC4nwUnVH/8/Im3yEHQP4b67cXlD/Qr9hdITCU1xDbSEXg2XKNaP8jsReV7vQd00/A=="
+    },
+    "minimalistic-crypto-utils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/minimalistic-crypto-utils/-/minimalistic-crypto-utils-1.0.1.tgz",
+      "integrity": "sha1-9sAMHAsIIkblxNmd+4x8CDsrWCo="
     },
     "morgan": {
       "version": "1.10.0",
@@ -444,6 +523,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
+    "scrypt-js": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz",
+      "integrity": "sha512-4KsaGcPnuhtCZQCxFxN3GVYIhKFPTdLd8PLC552XwbMndtD0cjRFAhDuuydXQ0h08ZfPgzqe6EKHozpuH74iDw=="
+    },
     "semver": {
       "version": "5.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
@@ -487,6 +571,11 @@
         "send": "0.17.1"
       }
     },
+    "setimmediate": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.4.tgz",
+      "integrity": "sha1-IOgd5iLUoCWIzgyNqJc8vPHTE48="
+    },
     "setprototypeof": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.1.tgz",
@@ -521,10 +610,20 @@
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
       "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
+    "uuid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.1.tgz",
+      "integrity": "sha1-wqMN7bPlNdcsz4LjQ5QaULqFM6w="
+    },
     "vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
       "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
+    },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
     }
   }
 }

--- a/examples/server/express/package.json
+++ b/examples/server/express/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "body-parser": "^1.19.0",
+    "ethers": "^4.0.45",
     "express": "^4.17.1",
     "morgan": "^1.10.0",
     "passport": "^0.4.1",

--- a/examples/server/express/passport.js
+++ b/examples/server/express/passport.js
@@ -1,4 +1,5 @@
 const passport = require('passport');
+const providers = require('ethers/providers');
 const { LoginStrategy } = require('../../../dist')
 
 const LOGIN_STRATEGY = 'login'
@@ -12,7 +13,8 @@ const jwtOptions = {
   secretOrKey: jwtSecret
 }
 module.exports.preparePassport = () => {
-  passport.use(new LoginStrategy({ jwtSecret, name: LOGIN_STRATEGY, rpcUrl: 'https://volta-rpc-vkn5r5zx4ke71f9hcu0c.energyweb.org/', cacheServerUrl: 'http://13.52.78.249:3333/' }))
+  const provider = new providers.JsonRpcProvider('https://volta-rpc-vkn5r5zx4ke71f9hcu0c.energyweb.org/')
+  passport.use(new LoginStrategy({ jwtSecret, name: LOGIN_STRATEGY, provider: provider, cacheServerUrl: 'http://13.52.78.249:3333/' }))
   passport.use(new Strategy(jwtOptions, function (payload, done) {
     return done(null, payload)
   }))

--- a/lib/LoginStrategy.ts
+++ b/lib/LoginStrategy.ts
@@ -27,7 +27,7 @@ const { abi: abi1056 } = ethrReg
 interface LoginStrategyOptions extends StrategyOptions {
   jwtSecret: string
   claimField?: string
-  rpcUrl: string
+  provider: providers.Provider
   cacheServerUrl?: string
   numberOfBlocksBack?: number
   ensResolverAddress?: string
@@ -38,7 +38,7 @@ interface LoginStrategyOptions extends StrategyOptions {
 export class LoginStrategy extends BaseStrategy {
   private claimField: string
   private jwtSecret: string
-  private provider: providers.JsonRpcProvider
+  private provider: providers.Provider
   private httpClient: AxiosInstance | undefined
   private numberOfBlocksBack: number
   private ensResolver: PublicResolver
@@ -47,7 +47,7 @@ export class LoginStrategy extends BaseStrategy {
   constructor(
     {
       claimField = 'claim',
-      rpcUrl,
+      provider,
       cacheServerUrl,
       numberOfBlocksBack = 4,
       jwtSecret,
@@ -60,7 +60,7 @@ export class LoginStrategy extends BaseStrategy {
   ) {
     super(options)
     this.claimField = claimField
-    this.provider = new providers.JsonRpcProvider(rpcUrl)
+    this.provider = provider
     this.ensResolver = PublicResolverFactory.connect(
       ensResolverAddress,
       this.provider


### PR DESCRIPTION
@ChangoBuitrago and I were discussing that it could be useful for standard HTTP clients (e.g. Postman) to be able to test server applications which are using the `LoginStrategy`. In this case, it would be useful to be able to reuse a login claim, which isn't currently possible due to the checking of recent block number in claim (which is done to prevent replay attacks). However, if one was able to inject a test ethers provider (https://docs.ethers.io/v4/cookbook-providers.html#custom-provider) into the `LoginStrategy`, then the block number returned could be controlled and the claim could be reused.

Currently, this PR makes the change to the `LoginStrategy` to inject the provider and changes the express example to instantiate the RPCProvider (the nest example would need to be changed too)

I think this PR relates somewhat to issue #6 .

@ChangoBuitrago @manihagh @dwojno Any thoughts on this change? Is there a better way to allow the use "standard" HTTP clients in testing scenarios?