### PR TITLE
Using issuer claims to verify "Role" type claim

### DIFF
--- a/lib/LoginStrategy.ts
+++ b/lib/LoginStrategy.ts
@@ -201,9 +201,9 @@ export class LoginStrategy extends BaseStrategy {
     }
 
     if (role.issuer?.issuerType === 'Role') {
-      if (!this.httpClient) return null
-      const dids = await this.getDidsWithAcceptedRole(role.issuer.roleName)
-      if (dids.includes(issuer)) {
+      const issuerClaims = await this.getUserClaims(issuer)
+      const issuerRoles = issuerClaims.map(c => c.claimType)
+      if (issuerRoles.includes(role.issuer.roleName)) {
         return {
           name: role.roleName,
           namespace,


### PR DESCRIPTION
@dwojno Would this approach work for verifying that a given issuer has a specific role? The advantage is that it doesn't rely on the cache-server. I haven't tested yet but thought I would run the idea by you