### PR TITLE
fix: stringify login failure reason

### DIFF
--- a/lib/cacheServerClient.ts
+++ b/lib/cacheServerClient.ts
@@ -39,7 +39,7 @@ export class CacheServerClient {
     const retry = Policy.handleAll().retry().attempts(10).delay(2000)
     retry.onFailure(({ reason }) => {
       console.log(
-        `DID login strategy was not able to login to cache server due to ${reason}`
+        `DID login strategy was not able to login to cache server due to ${JSON.stringify(reason, null, 4)}`
       )
     })
 


### PR DESCRIPTION
previously just printing: "[object Object]"