### PR TITLE
Feature/swtch 866 authenticate based on did document

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "10.22.0"
+  - "14.17.0"
 
 before_deploy:
   - git config --global user.email ${GITHUB_EMAIL}

--- a/lib/AuthTokenVerifier.ts
+++ b/lib/AuthTokenVerifier.ts
@@ -1,0 +1,91 @@
+import { JWT } from '@ew-did-registry/jwt';
+import { Keys } from '@ew-did-registry/keys';
+import { IAuthentication, IDIDDocument, IPublicKey } from "@ew-did-registry/did-resolver-interface";
+
+export class AuthTokenVerifier {
+
+    private readonly privateKey: string
+    private readonly didDocument: IDIDDocument
+
+    constructor(
+        private readonly _privateKey: string,
+        private readonly _didDocument: IDIDDocument
+    ) {
+        this.didDocument = _didDocument,
+        this.privateKey = _privateKey
+    }
+
+    /**
+   * @description checks a token was signed by the issuer DID or a valid authentication delegate of the issuer
+   *
+   * @param token
+   * @param issuerDID
+   *
+   * @returns {string} issuer DID or null
+   */
+    public async verify(token: string, issuerDID: string): Promise<string> {
+
+        if (await this.isAuthorized(token))
+            return issuerDID
+        return null
+    }
+
+    private isAuthorized = async (claimedToken: string): Promise<boolean> => {
+        //read publickey field in DID document
+        const didPubKey = this.didDocument.publicKey
+        if (didPubKey.length === 0)
+        return false
+        
+        const keys = new Keys({ privateKey: this.privateKey })
+        const jwtSigner = new JWT(keys)
+        
+        //get all authentication public keys
+        const authenticationPubkeys = this.didDocument.publicKey.filter(pubkey => {
+            return this.isAuthenticated(pubkey, this.didDocument.authentication)
+        })
+
+        const validKeys = await this.filterValidKeys(authenticationPubkeys, async (pubKeyField) => {
+            try {
+                const publickey = pubKeyField["publicKeyHex"]?.split('x')[1]
+                const decodedClaim = await jwtSigner.verify(claimedToken, publickey);
+                return decodedClaim !== undefined;
+            }
+            catch (error) {
+                return false
+            }
+        })
+        return validKeys.length !== 0
+    }
+
+    private filterValidKeys = async (authenticatedKey: IPublicKey[], verifSignature) => {
+        const results = await Promise.all(authenticatedKey.map(verifSignature));
+
+        return authenticatedKey.filter((_key, index) => results[index]);
+    }
+
+    private isAuthenticated = (publicKey: IPublicKey, authFieldDocument: (string | IAuthentication)[]) => {
+        if (authFieldDocument.length === 0 && publicKey !== undefined)
+            return this.isSigAuth(publicKey["type"])
+        const authenticationKeys = authFieldDocument.map(auth => {
+
+            return (this.areLinked(auth["publicKey"], publicKey["id"]))
+        })
+        return authenticationKeys.includes(true);
+    }
+
+    //used to compare ids in DID Since the referenced pubkey id differs slighty from the auth reference Id
+    private areLinked = (authId: string, pubKeyID: string) => {
+        if (authId === pubKeyID)
+            return true
+        if (authId.includes("#")) {
+            const [idRef, typeRef] = authId.split("#")
+            return `${idRef}#key-${typeRef}` === pubKeyID
+        }
+        return false
+    }
+
+    private isSigAuth = (pubKeyType: string) => {
+        const extractedType = pubKeyType.substring(pubKeyType.length - 7);
+        return extractedType === "sigAuth"
+    }
+}

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -71,19 +71,3 @@ export function lookup(obj: {}, field: string): string | null {
   return null
 }
 
-export const verifyClaim = (token: string, { iss }: ITokenPayload) => {
-  const [encodedHeader, encodedPayload, encodedSignature] = token.split('.')
-  const msg = `0x${Buffer.from(`${encodedHeader}.${encodedPayload}`).toString(
-    'hex'
-  )}`
-  const signature = base64url.decode(encodedSignature)
-  const hash = arrayify(keccak256(msg))
-  const decodedAddress = iss.split(':')[2]
-  const address = recoverAddress(hash, signature)
-  if (decodedAddress === address) {
-    return iss
-  }
-  const digest = arrayify(hashMessage(hash))
-  const addressFromDigest = recoverAddress(digest, signature)
-  return decodedAddress === addressFromDigest ? iss : ''
-}

--- a/test/AuthTokenVerifier.test.ts
+++ b/test/AuthTokenVerifier.test.ts
@@ -1,0 +1,105 @@
+import assert from 'assert';
+import { JWT } from '@ew-did-registry/jwt';
+import { ClaimData } from './claim-creation/ClaimData';
+import { AuthTokenVerifier } from '../lib/AuthTokenVerifier';
+import {
+  firstKeys,
+  secondKeys, 
+  firstDocument,
+  secondDocument, 
+  emptyAuthenticationDocument,
+} from './TestDidDocuments';
+import { JwtPayload } from '@ew-did-registry/jwt/dist/sign';
+
+let firstClaimToken: string;
+let claimData: ClaimData;
+let secondClaimToken: string;
+let firstSigner : JWT;
+let secondSigner : JWT;
+let firstPayload: JwtPayload;
+let secondPayload: JwtPayload;
+let tokenAuthenticationVerifier: AuthTokenVerifier
+
+const issuerDID = `did:ethr:${firstKeys.getAddress()}`
+const secondDID = `did:ethr:${secondKeys.getAddress()}`
+
+describe("Testing AuthTokenVerifier", () => {
+
+  beforeAll(async () => {
+    claimData = {
+      claimType: "user.roles.example1.apps.john.iam.ewc",
+    }
+    
+    firstPayload = {
+      claimType: "user.roles.example1.apps.john.iam.ewc",
+      claimData: {
+        blockNumber: 42,
+        text: 'In EWC we trust'
+      },
+      iss: issuerDID,
+      sub: secondDID
+    }
+
+    secondPayload = {
+      claimType: "user.roles.example1.apps.john.iam.ewc",
+      claimData: {
+        blockNumber: 42,
+        text: 'In EWC we trust'
+      },
+      iss: secondDID,
+      sub: secondDID
+    }
+
+    firstSigner = new JWT(firstKeys);
+    secondSigner = new JWT(secondKeys)
+    firstClaimToken = await firstSigner.sign(firstPayload, { algorithm: 'ES256' });
+    secondClaimToken = await secondSigner.sign(secondPayload, { algorithm: 'ES256' });
+  })
+
+  it("Checks if basic signing verification works", async () => {
+    const testSignature = await secondSigner.sign('Initial signed content', { algorithm: 'ES256' })
+    const secondPubKey = secondKeys.publicKey
+    const decoded = await secondSigner.verify(testSignature, secondPubKey)
+    
+    assert.strictEqual(decoded, 'Initial signed content')
+  })
+
+  it("should authenticate first DID with first Claim issuer", async () => {
+    
+    tokenAuthenticationVerifier = new AuthTokenVerifier(firstKeys.privateKey, firstDocument);
+    const did = await tokenAuthenticationVerifier.verify(firstClaimToken, firstPayload.iss)
+
+    assert.strictEqual(did, issuerDID)
+  })
+
+  it("should reject the second DID authentication with first Claim issuer", async () => {
+    
+    tokenAuthenticationVerifier = new AuthTokenVerifier(firstKeys.privateKey, firstDocument);
+    const did = await tokenAuthenticationVerifier.verify(secondClaimToken, firstPayload.iss)
+
+    assert.strictEqual(did, null)
+  })
+
+  it("should reject first DID with second Claim issuer", async () => {
+    tokenAuthenticationVerifier = new AuthTokenVerifier(secondKeys.privateKey, secondDocument);
+    const did = await tokenAuthenticationVerifier.verify(firstClaimToken, secondPayload.iss)
+    
+    assert.strictEqual(did, null)
+  })
+
+  it("should authenticate second DID with second Claim issuer", async () => {
+    
+    tokenAuthenticationVerifier = new AuthTokenVerifier(secondKeys.privateKey, secondDocument);
+    const did = await tokenAuthenticationVerifier.verify(secondClaimToken, secondPayload.iss)
+    
+    assert.strictEqual(did, secondDID)
+  })
+
+  it("should authenticate sigAuth on empty authentication DID", async () => {
+    
+    tokenAuthenticationVerifier = new AuthTokenVerifier(secondKeys.privateKey, emptyAuthenticationDocument);
+    const did = await tokenAuthenticationVerifier.verify(secondClaimToken, secondPayload.iss)
+    
+    assert.strictEqual(did, secondDID)
+  })
+})

--- a/test/TestDidDocuments.ts
+++ b/test/TestDidDocuments.ts
@@ -1,0 +1,83 @@
+import { Keys } from '@ew-did-registry/keys'
+import {IDIDDocument} from "@ew-did-registry/did-resolver-interface"
+
+export const firstKeys = new Keys();
+export const secondKeys = new Keys();
+
+export const firstDocument : IDIDDocument = {
+    id: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3',
+    authentication: [
+      {
+        type: 'owner',
+        validity: [Object],
+        publicKey: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#owner'
+      }
+    ],
+    created: null,
+    delegates: null,
+    proof: null,
+    publicKey: [
+      {
+        id: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#key-owner',
+        type: 'Secp256k1veriKey',
+        controller: '0x72EFf9faB7876c4c1b6cAe426c121358431758F3',
+        publicKeyHex: '0x' + firstKeys.publicKey
+      },
+      {
+        id: 'did:ethr:0x731ac21Aa72c1A6E15243AFBB34cA9CC073D419B#key-owner',
+        type: 'Secp256k1veriKey',
+        controller: '0x731ac21Aa72c1A6E15243AFBB34cA9CC073D419B',
+        publicKeyHex: '0x037cff69ef821172f5df74d3f9406679cc27aba2d96438211538deeb325c9d434d'
+      }
+    ],
+    updated: null,
+    '@context': 'https://www.w3.org/ns/did/v1',
+}
+
+export const secondDocument : IDIDDocument = {
+  id: 'did:ethr:0x0E46cbecF1742DdEb29BBC56F27ad236483443b7',
+  authentication: [
+    {
+      type: 'owner',
+      validity: [Object],
+      publicKey: 'did:ethr:0x0E46cbecF1742DdEb29BBC56F27ad236483443b7#owner'
+    }
+  ],
+  created: null,
+  delegates: null,
+  proof: null,
+  publicKey: [
+    {
+      id: 'did:ethr:0xA533557F26477b1fA7BFa76E6eD5467D9Bc9d633#809ea74d-50c8-451b-a7ce-2fe37b724e0d',
+      type: 'Secp256k1sigAuth',
+      controller: '0xA533557F26477b1fA7BFa76E6eD5467D9Bc9d633',
+      publicKeyHex: 'mynewkey'
+    },
+    {
+      id: 'did:ethr:0x0E46cbecF1742DdEb29BBC56F27ad236483443b7#key-owner',
+      type: 'Secp256k1veriKey',
+      controller: '0x0E46cbecF1742DdEb29BBC56F27ad236483443b7',
+      publicKeyHex: '0x' + secondKeys.publicKey
+    }
+  ],
+  updated: null,
+  '@context': 'https://www.w3.org/ns/did/v1',
+}
+
+export const emptyAuthenticationDocument : IDIDDocument = {
+  id: 'did:ethr:0x0E46cbecF1742DdEb29BBC56F27ad236483443b7',
+  authentication: [],
+  created: null,
+  delegates: null,
+  proof: null,
+  publicKey: [
+    {
+      id: 'did:ethr:0xA533557F26477b1fA7BFa76E6eD5467D9Bc9d633#809ea74d-50c8-451b-a7ce-2fe37b724e0d',
+      type: 'Secp256k1sigAuth',
+      controller: '0xA533557F26477b1fA7BFa76E6eD5467D9Bc9d633',
+      publicKeyHex: '0x' + secondKeys.publicKey
+    }
+  ],
+  updated: null,
+  '@context': 'https://www.w3.org/ns/did/v1',
+}


### PR DESCRIPTION
### Description
> Currently, passport-did-auth authenticates a user by confirming that the address which signed the presented authentication token/credential is the address of the DID document (code). However, passport-did-auth should instead reference the authentication property of the document of the claimed DID

#### Pull request Content:
* Update: In LoginStrategy.ts, I replaced the verifyClaim function (imported from utils.ts) by the `verify` function.
This function is a method of  a new `AuthTokenVerifier` class, which checks into the authentication field of the DID to validate the tonken issuer's signature.

* Added a `AuthTokenVerifier.test.ts` file containing unit tests of the new `AuthTokenVerifier.verify` method.

* Added a `TestDidDocuments.ts` file to provide testing DiD documents a signers for unit tests

* Some light reformating of LoginStrategy.ts code is implied 