### PR TITLE
Fix/pda 2/tag agnostic pub key comparaison

### DIFF
--- a/lib/AuthTokenVerifier.ts
+++ b/lib/AuthTokenVerifier.ts
@@ -32,15 +32,15 @@ export class AuthTokenVerifier {
 
     private isAuthorized = async (claimedToken: string): Promise<boolean> => {
         //read publickey field in DID document
-        const didPubKey = this.didDocument.publicKey
-        if (didPubKey.length === 0)
-        return false
+        const didPubKeys = this.didDocument.publicKey
+        if (didPubKeys.length === 0)
+            return false
         
         const keys = new Keys({ privateKey: this.privateKey })
         const jwtSigner = new JWT(keys)
         
         //get all authentication public keys
-        const authenticationPubkeys = this.didDocument.publicKey.filter(pubkey => {
+        const authenticationPubkeys = didPubKeys.filter(pubkey => {
             return this.isAuthenticationKey(pubkey, this.didDocument.authentication)
         })
 

--- a/lib/AuthTokenVerifier.ts
+++ b/lib/AuthTokenVerifier.ts
@@ -84,14 +84,12 @@ export class AuthTokenVerifier {
         return authenticationKeys.includes(true);
     }
 
-    //used to compare ids in DID Since the referenced pubkey id differs slighty from the auth reference Id
+    //used to check if publicKey field in authentication refers to the publicKey ID in publicKey field
     private areLinked = (authId: string, pubKeyID: string) => {
         if (authId === pubKeyID)
             return true
-        if (authId.includes("#")) {
-            const [idRef, typeRef] = authId.split("#")
-            return `${idRef}#key-${typeRef}` === pubKeyID
-        }
+        if (authId.includes("#"))
+            return pubKeyID.split("#")[0] == authId.split("#")[0]
         return false
     }
 

--- a/test/Login.test.ts
+++ b/test/Login.test.ts
@@ -86,10 +86,9 @@ it('Can Log in',  async () => {
 
     //create a key
     const assetKeys = new Keys();
-    //const assetWallet = new Wallet(assetKeys.privateKey);
-    
-    //const pubKey = utils.computePublicKey(assetWallet.publicKey, true);
     console.log("Asset pubkey", assetKeys.publicKey);
+    console.log("Before update DidDoc: ", await iam.getDidDocument())
+
     //add to asset
     const assetDid = `did:ethr:${assetAddress}`;
     const isDIdDocUpdated = await iam.updateDidDocument({
@@ -99,11 +98,11 @@ it('Can Log in',  async () => {
             algo: Algorithms.Secp256k1,
             encoding: Encoding.HEX,
             type: PubKeyType.SignatureAuthentication2018,
-            value: { tag: "key-owner", publicKey: `${assetKeys.publicKey}` },
-            //value: { tag: "key-owner", publicKey: `${assetKeys.publicKey}` },
+            value: { tag: "key-1", publicKey: `0x${assetKeys.publicKey}` },
         },
     });
     assert.isTrue(isDIdDocUpdated, "The asset has not been added to document");
+    console.log("After update DidDoc: ", await iam.getDidDocument());
     
     //create IdentityProofWithDelegate
 
@@ -112,14 +111,13 @@ it('Can Log in',  async () => {
         rpcUrl,
         assetDid
         );
-        // const identityToken = await iam.createIdentityProof();
         const identityToken = token;
         console.log("IdentityToken >> ", identityToken);
 
     await request(getServer(didContract.address))
         .post('/login')
         .send({identityToken})
-        .expect(200);
+        .expect(200)
         // TODO: expect jwt token
         // TODO: ensure that test ends afterwards
 });


### PR DESCRIPTION
This PR removes the tag dependency when comparing publicKeys and and authentication keys on a DID.
Only the string before the '#' hashtag is releavant to check key binding.

In the example document below

```
{
    id: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3',
    authentication: [
      {
        type: 'owner',
        validity: [Object],
        publicKey: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#owner'
      }
    ],
    created: null,
    delegates: null,
    proof: null,
    publicKey: [
      {
        id: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#any-key-tag',
        type: 'Secp256k1veriKey',
        controller: '0x72EFf9faB7876c4c1b6cAe426c121358431758F3',
        publicKeyHex: '0x' + firstKeys.publicKey
      },
      {
        id: 'did:ethr:0x731ac21Aa72c1A6E15243AFBB34cA9CC073D419B#key-owner',
        type: 'Secp256k1veriKey',
        controller: '0x731ac21Aa72c1A6E15243AFBB34cA9CC073D419B',
        publicKeyHex: '0x037cff69ef821172f5df74d3f9406679cc27aba2d96438211538deeb325c9d434d'
      }
    ],
    updated: null,
    '@context': 'https://www.w3.org/ns/did/v1',
}
```

The publicKey in `authentication` field with value ` 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#owner'` will now
match the id  `'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#any-key-tag'`  in publicKey field, whereas previously it would have matched only the id `'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#key-owner'`.