### PR TITLE
test(AuthTokenVerifier): add empty doc test

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -184,7 +184,7 @@ export default {
   // unmockedModulePathPatterns: undefined,
 
   // Indicates whether each individual test should be reported during the run
-  // verbose: undefined,
+  verbose: true,
 
   // An array of regexp patterns that are matched against all source file paths before re-running tests in watch mode
   // watchPathIgnorePatterns: [],

--- a/lib/AuthTokenVerifier.ts
+++ b/lib/AuthTokenVerifier.ts
@@ -1,92 +1,132 @@
+import { JWT } from "@ew-did-registry/jwt";
+import { Keys } from "@ew-did-registry/keys";
+import {
+  IAuthentication,
+  IDIDDocument,
+  IPublicKey,
+  PubKeyType,
+} from "@ew-did-registry/did-resolver-interface";
+import { utils } from "ethers";
+import base64url from "base64url";
 
-import { JWT } from '@ew-did-registry/jwt';
-import { Keys } from '@ew-did-registry/keys';
-import { IAuthentication, IDIDDocument, IPublicKey } from "@ew-did-registry/did-resolver-interface";
+const { arrayify, recoverAddress, keccak256, hashMessage } = utils;
 
 export class AuthTokenVerifier {
   private _jwt = new JWT(new Keys());
   constructor(private readonly _didDocument: IDIDDocument) {}
 
-    /**
+  /**
    * @description checks a token was signed by the issuer DID or a valid authentication delegate of the issuer
    *
    * @param token
-   * @param issuerDID
    *
-   * @returns {string} issuer DID or null
+   * @returns {string} Authenticated identity DID
    */
-    public async verify(token: string, issuerDID: string): Promise<string | null> {
-        if (await this.isAuthorized(token))
-            return issuerDID
-        return null
+  public async verify(token: string): Promise<string | null> {
+    if ((await this.isIdentity(token)) || (await this.isDelegate(token))) {
+      return this._didDocument.id;
+    }
+    return null;
+  }
+
+  /**
+   * @description Determines if a token was signed with an Ethereum signature by the address in the id of the DID Document
+   * Not that JWT-compliant signatures can't be used to recover an ethereum 
+   */
+  private async isIdentity(token: string) {
+    const [encodedHeader, encodedPayload, encodedSignature] = token.split(".");
+    const msg = `0x${Buffer.from(`${encodedHeader}.${encodedPayload}`).toString(
+      "hex"
+    )}`;
+    const signature = base64url.decode(encodedSignature);
+    const hash = arrayify(keccak256(msg));
+    const claimedAddress = this._didDocument.id.split(":")[2];
+    try {
+      if (claimedAddress === recoverAddress(hash, signature)) {
+        return true;
+      }
+    } catch (_) {}
+    const digest = arrayify(hashMessage(hash));
+    try {
+      if (claimedAddress === recoverAddress(digest, signature)) {
+        return true;
+      }
+    } catch (_) {}
+    return false;
+  }
+
+  private async isDelegate(token: string) {
+    const didPubKeys = this._didDocument.publicKey;
+    if (didPubKeys.length === 0) {
+      return false;
     }
 
-    private isAuthorized = async (claimedToken: string): Promise<boolean> => {
-        //read publickey field in DID document
-        const didPubKeys = this.didDocument.publicKey
-        if (didPubKeys.length === 0) {
-            return false
+    const authenticationPubkeys = didPubKeys.filter((pubkey) => {
+      return this.isAuthenticationKey(pubkey, this._didDocument.authentication);
+    });
+    const validKeys = await this.filterValidKeys(
+      authenticationPubkeys,
+      async (pubKeyField) => {
+        try {
+          const parts = pubKeyField["publicKeyHex"]?.split("x");
+          const publickey = parts.length == 2 ? parts[1] : parts[0];
+          const decodedClaim = await this._jwt.verify(token, publickey);
+
+          return decodedClaim !== undefined;
+        } catch (error) {
+          return false;
         }
-        
-        const keys = new Keys({ privateKey: this.privateKey })
-        const jwtSigner = new JWT(keys)
-        
-        //get all authentication public keys
-        const authenticationPubkeys = didPubKeys.filter(pubkey => {
-            return this.isAuthenticationKey(pubkey, this.didDocument.authentication)
-        })
+      }
+    );
+    return validKeys.length !== 0;
+  }
 
-        const validKeys = await this.filterValidKeys(authenticationPubkeys, async (pubKeyField) => {
-            try {
-                console.log(pubKeyField)
-                const parts = pubKeyField["publicKeyHex"]?.split('x')
-                const publickey = parts.length == 2 ? parts[1] : parts[0]
-                console.log(publickey)
-                const decodedClaim = await jwtSigner.verify(claimedToken, publickey);
-                return decodedClaim !== undefined;
-            }
-            catch (error) {
-                return false
-            }
-        })
-        return validKeys.length !== 0
-    }
+  private filterValidKeys = async (
+    authenticatedKey: IPublicKey[],
+    verifSignature
+  ) => {
+    const results = await Promise.all(authenticatedKey.map(verifSignature));
 
-    private filterValidKeys = async (authenticatedKey: IPublicKey[], verifSignature) => {
-        const results = await Promise.all(authenticatedKey.map(verifSignature));
+    return authenticatedKey.filter((_key, index) => results[index]);
+  };
 
-        return authenticatedKey.filter((_key, index) => results[index]);
-    }
-
-    /**
-     * The authentication token should be signed by an "authentication" key of the DID (https://www.w3.org/TR/did-core/#authentication)
-     * There are two ways to determine an authentication key.
-     * 1. The publicKey's type is "sigAuth"
-     * 2. The publicKey's id is in the authentication array of the DID document
-     * @param publicKey The publicKey to test
-     * @param documentAuthField The authentication array of the DID document
-     * @returns whether or not the key is an authentication key
-     */
+  /**
+   * The authentication token should be signed by an "authentication" key of the DID (https://www.w3.org/TR/did-core/#authentication)
+   * There are two ways to determine an authentication key.
+   * 1. The publicKey's type is "sigAuth"
+   * 2. The publicKey's id is in the authentication array of the DID document
+   * @param publicKey The publicKey to test
+   * @param documentAuthField The authentication array of the DID document
+   * @returns whether or not the key is an authentication key
+   */
+  private isAuthenticationKey = (
+    publicKey: IPublicKey,
+    documentAuthField: (string | IAuthentication)[]
+  ) => {
     if (this.isSigAuth(publicKey.type)) {
       return true;
     }
     if (documentAuthField.length === 0) {
       return false;
     }
+    const authenticationKeys = documentAuthField.map((auth) => {
+      return this.areLinked(auth["publicKey"], publicKey["id"]);
+    });
+    return authenticationKeys.includes(true);
+  };
 
-    //used to check if publicKey field in authentication refers to the publicKey ID in publicKey field
-    private areLinked = (authId: string, pubKeyID: string) => {
-        if (authId === pubKeyID) {
-            return true
-        }
-        if (authId.includes("#")) {
-            return pubKeyID.split("#")[0] == authId.split("#")[0]
-        }
-        return false
+  //used to check if publicKey field in authentication refers to the publicKey ID in publicKey field
+  private areLinked = (authId: string, pubKeyID: string) => {
+    if (authId === pubKeyID) {
+      return true;
     }
+    if (authId.includes("#")) {
+      return pubKeyID.split("#")[0] == authId.split("#")[0];
+    }
+    return false;
+  };
 
-    private isSigAuth = (pubKeyType: string) => {
-        const extractedType = pubKeyType.substring(pubKeyType.length - 7);
-        return extractedType === "sigAuth"
-    }
+  private isSigAuth = (pubKeyType: string) => {
+    return pubKeyType.endsWith(PubKeyType.SignatureAuthentication2018);
+  };
 }

--- a/lib/AuthTokenVerifier.ts
+++ b/lib/AuthTokenVerifier.ts
@@ -4,17 +4,8 @@ import { Keys } from '@ew-did-registry/keys';
 import { IAuthentication, IDIDDocument, IPublicKey } from "@ew-did-registry/did-resolver-interface";
 
 export class AuthTokenVerifier {
-
-    private readonly privateKey: string
-    private readonly didDocument: IDIDDocument
-
-    constructor(
-        private readonly _privateKey: string,
-        private readonly _didDocument: IDIDDocument
-    ) {
-        this.didDocument = _didDocument,
-        this.privateKey = _privateKey
-    }
+  private _jwt = new JWT(new Keys());
+  constructor(private readonly _didDocument: IDIDDocument) {}
 
     /**
    * @description checks a token was signed by the issuer DID or a valid authentication delegate of the issuer

--- a/lib/AuthTokenVerifier.ts
+++ b/lib/AuthTokenVerifier.ts
@@ -67,14 +67,11 @@ export class AuthTokenVerifier {
      * @param documentAuthField The authentication array of the DID document
      * @returns whether or not the key is an authentication key
      */
-    private isAuthenticationKey = (publicKey: IPublicKey, documentAuthField: (string | IAuthentication)[]) => {
-        if (documentAuthField.length === 0 && publicKey !== undefined) {
-            return this.isSigAuth(publicKey["type"])
-        }
-        const authenticationKeys = documentAuthField.map(auth => {
-            return (this.areLinked(auth["publicKey"], publicKey["id"]))
-        })
-        return authenticationKeys.includes(true);
+    if (this.isSigAuth(publicKey.type)) {
+      return true;
+    }
+    if (documentAuthField.length === 0) {
+      return false;
     }
 
     //used to check if publicKey field in authentication refers to the publicKey ID in publicKey field

--- a/lib/LoginStrategy.ts
+++ b/lib/LoginStrategy.ts
@@ -120,8 +120,8 @@ export class LoginStrategy extends BaseStrategy {
     const didDocument = this.cacheServerClient?.isAvailable 
       ? await this.cacheServerClient.getDidDocument(payload.iss)
       :  await this.didResolver.read(payload.iss)
-    const authenticationClaimVerifier = new AuthTokenVerifier(this.privateKey, didDocument)
-    const did = await authenticationClaimVerifier.verify(token, payload.iss)
+    const authenticationClaimVerifier = new AuthTokenVerifier(didDocument)
+    const did = await authenticationClaimVerifier.verify(token)
 
     if (!did) {
       console.log('Not Verified')

--- a/package-lock.json
+++ b/package-lock.json
@@ -1790,6 +1790,13 @@
         "@types/sjcl": "1.0.28",
         "eciesjs": "^0.3.4",
         "sjcl": "npm:sjcl-complete@1.0.0"
+      },
+      "dependencies": {
+        "sjcl": {
+          "version": "npm:sjcl-complete@1.0.0",
+          "resolved": "https://registry.npmjs.org/sjcl-complete/-/sjcl-complete-1.0.0.tgz",
+          "integrity": "sha512-nZx2bBY8jbx4cLjSToaUG0cI7J2mNBx2Op9T+eBBkiNe3xrFUkAHyZP0vEB6E8Q8iIDL6Qx8Yaf48pZJiq9JMQ=="
+        }
       }
     },
     "@ew-did-registry/did": {
@@ -9212,6 +9219,12 @@
           "requires": {
             "side-channel": "^1.0.4"
           }
+        },
+        "sjcl": {
+          "version": "npm:sjcl-complete@1.0.0",
+          "resolved": "https://registry.npmjs.org/sjcl-complete/-/sjcl-complete-1.0.0.tgz",
+          "integrity": "sha512-nZx2bBY8jbx4cLjSToaUG0cI7J2mNBx2Op9T+eBBkiNe3xrFUkAHyZP0vEB6E8Q8iIDL6Qx8Yaf48pZJiq9JMQ==",
+          "dev": true
         },
         "uuid": {
           "version": "7.0.3",
@@ -17424,11 +17437,6 @@
       "resolved": "https://registry.npmjs.org/sisteransi/-/sisteransi-1.0.5.tgz",
       "integrity": "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==",
       "dev": true
-    },
-    "sjcl": {
-      "version": "npm:sjcl-complete@1.0.0",
-      "resolved": "https://registry.npmjs.org/sjcl-complete/-/sjcl-complete-1.0.0.tgz",
-      "integrity": "sha512-nZx2bBY8jbx4cLjSToaUG0cI7J2mNBx2Op9T+eBBkiNe3xrFUkAHyZP0vEB6E8Q8iIDL6Qx8Yaf48pZJiq9JMQ=="
     },
     "slash": {
       "version": "3.0.0",

--- a/test/AuthTokenVerifier.test.ts
+++ b/test/AuthTokenVerifier.test.ts
@@ -1,100 +1,158 @@
-import assert from 'assert';
-import { JWT } from '@ew-did-registry/jwt';
-import { AuthTokenVerifier } from '../lib/AuthTokenVerifier';
+import assert from "assert";
+import { Wallet, utils } from "ethers";
 import {
-  firstKeys,
-  secondKeys, 
-  firstDocument,
-  secondDocument, 
-  emptyAuthenticationDocument,
-} from './TestDidDocuments';
-import { JwtPayload } from '@ew-did-registry/jwt/dist/sign';
+  createSignWithEthersSigner,
+  createSignWithKeys,
+} from "@ew-did-registry/jwt/dist/sign";
+import { AuthTokenVerifier } from "../lib/AuthTokenVerifier";
+import { mockDocument } from "./TestDidDocuments";
+import { Methods } from "@ew-did-registry/did";
+import { Keys } from "@ew-did-registry/keys";
+import {
+  IAuthentication,
+  IPublicKey,
+  PubKeyType,
+} from "@ew-did-registry/did-resolver-interface";
 
-let firstClaimToken: string;
-let secondClaimToken: string;
-let firstSigner : JWT;
-let secondSigner : JWT;
-let firstPayload: JwtPayload;
-let secondPayload: JwtPayload;
-let tokenAuthenticationVerifier: AuthTokenVerifier
+const { computePublicKey } = utils;
 
-const issuerDID = `did:ethr:${firstKeys.getAddress()}`
-const secondDID = `did:ethr:${secondKeys.getAddress()}`
+const payload = {
+  claimType: "user.roles.example1.apps.john.iam.ewc",
+  claimData: {
+    blockNumber: 42,
+    text: "In EWC we trust",
+  },
+};
+const identity = Wallet.createRandom();
 
-describe("Testing AuthTokenVerifier", () => {
+const createEthersClaim = async (delegate?: Wallet) => {
+  if (!delegate) {
+    delegate = identity;
+  }
+  const DID = `did:${Methods.Erc1056}:${identity.address}`;
+  return createSignWithEthersSigner(delegate)({
+    ...payload,
+    iss: DID,
+  });
+};
+const createJwtClaim = async (delegate?: Wallet) => {
+  if (!delegate) {
+    delegate = identity;
+  }
+  const DID = `did:${Methods.Erc1056}:${identity.address}`;
+  return createSignWithKeys(
+    new Keys({ privateKey: delegate.privateKey.slice(2) })
+  )(payload, { issuer: DID, algorithm: "ES256" });
+};
 
-  beforeAll(async () => {
-    
-    firstPayload = {
-      claimType: "user.roles.example1.apps.john.iam.ewc",
-      claimData: {
-        blockNumber: 42,
-        text: 'In EWC we trust'
-      },
-      iss: issuerDID,
-      sub: secondDID
-    }
+describe("AuthTokenVerifier", () => {
+  let verifier: AuthTokenVerifier;
+  let claim: string;
 
-    secondPayload = {
-      claimType: "user.roles.example1.apps.john.iam.ewc",
-      claimData: {
-        blockNumber: 42,
-        text: 'In EWC we trust'
-      },
-      iss: secondDID,
-      sub: secondDID
-    }
+  describe("Authenticate as identity", () => {
+    it("should authenticate with empty document", async () => {
+      claim = await createEthersClaim(identity);
+      const document = mockDocument(identity, {
+        withOwnerKey: false,
+      });
+      verifier = new AuthTokenVerifier(document);
+      const did = await verifier.verify(claim);
 
-    firstSigner = new JWT(firstKeys);
-    secondSigner = new JWT(secondKeys)
-    firstClaimToken = await firstSigner.sign(firstPayload, { algorithm: 'ES256' });
-    secondClaimToken = await secondSigner.sign(secondPayload, { algorithm: 'ES256' });
-  })
+      assert.strictEqual(did, document.id);
+    });
 
-  it("Checks if basic signing verification works", async () => {
-    const testSignature = await secondSigner.sign('Initial signed content', { algorithm: 'ES256' })
-    const secondPubKey = secondKeys.publicKey
-    const decoded = await secondSigner.verify(testSignature, secondPubKey)
-    
-    assert.strictEqual(decoded, 'Initial signed content')
-  })
+    it("should not authenticate with other identity document", async () => {
+      claim = await createEthersClaim(identity);
+      const document = mockDocument(Wallet.createRandom(), {
+        withOwnerKey: false,
+      });
+      verifier = new AuthTokenVerifier(document);
+      const did = await verifier.verify(claim);
 
-  it("should authenticate first DID with first Claim issuer", async () => {
-    
-    tokenAuthenticationVerifier = new AuthTokenVerifier(firstKeys.privateKey, firstDocument);
-    const did = await tokenAuthenticationVerifier.verify(firstClaimToken, firstPayload.iss)
+      assert.strictEqual(did, null);
+    });
+  });
 
-    assert.strictEqual(did, issuerDID)
-  })
+  describe("Authenticate as delegate", () => {
+    let createClaim;
+    const delegateTests = () => {
+      it("sigAuth delegate should be authenticated", async () => {
+        const delegate = Wallet.createRandom();
+        const document = mockDocument(identity);
+        document.publicKey.push({
+          id: `did:${Methods.Erc1056}:${delegate.address}#${PubKeyType.SignatureAuthentication2018}`,
+          type: PubKeyType.SignatureAuthentication2018,
+          publicKeyHex: computePublicKey(delegate.publicKey, true),
+        } as IPublicKey);
+        verifier = new AuthTokenVerifier(document);
+        claim = await createClaim(delegate);
+        const did = await verifier.verify(claim);
 
-  it("should reject the second DID authentication with first Claim issuer", async () => {
-    
-    tokenAuthenticationVerifier = new AuthTokenVerifier(firstKeys.privateKey, firstDocument);
-    const did = await tokenAuthenticationVerifier.verify(secondClaimToken, firstPayload.iss)
+        assert.strictEqual(did, document.id);
+      });
 
-    assert.strictEqual(did, null)
-  })
+      it("authentication delegate should be authenticated", async () => {
+        const delegate = Wallet.createRandom();
+        const document = mockDocument(identity);
+        document.publicKey.push({
+          id: `did:${Methods.Erc1056}:${delegate.address}#${PubKeyType.VerificationKey2018}`,
+          type: PubKeyType.VerificationKey2018,
+          publicKeyHex: computePublicKey(delegate.publicKey, true),
+        } as IPublicKey);
+        document.authentication.push({
+          publicKey: `did:${Methods.Erc1056}:${delegate.address}#delegate`,
+        } as IAuthentication);
+        verifier = new AuthTokenVerifier(document);
+        claim = await createClaim(delegate);
+        const did = await verifier.verify(claim);
 
-  it("should reject first DID with second Claim issuer", async () => {
-    tokenAuthenticationVerifier = new AuthTokenVerifier(secondKeys.privateKey, secondDocument);
-    const did = await tokenAuthenticationVerifier.verify(firstClaimToken, secondPayload.iss)
-    
-    assert.strictEqual(did, null)
-  })
+        assert.strictEqual(did, document.id);
+      });
 
-  it("should authenticate second DID with second Claim issuer", async () => {
-    
-    tokenAuthenticationVerifier = new AuthTokenVerifier(secondKeys.privateKey, secondDocument);
-    const did = await tokenAuthenticationVerifier.verify(secondClaimToken, secondPayload.iss)
-    
-    assert.strictEqual(did, secondDID)
-  })
+      it("should reject authentication with mismatching DID doc", async () => {
+        const delegate = Wallet.createRandom();
+        const document = mockDocument(identity);
+        verifier = new AuthTokenVerifier(document);
+        claim = await createClaim(delegate);
+        const did = await verifier.verify(claim);
 
-  it("should authenticate sigAuth on empty authentication DID", async () => {
-    
-    tokenAuthenticationVerifier = new AuthTokenVerifier(secondKeys.privateKey, emptyAuthenticationDocument);
-    const did = await tokenAuthenticationVerifier.verify(secondClaimToken, secondPayload.iss)
-    
-    assert.strictEqual(did, secondDID)
-  })
-})
+        assert.strictEqual(did, null);
+      });
+    };
+
+    describe("With Ethers signature", () => {
+      beforeAll(() => {
+        createClaim = createEthersClaim;
+      });
+      delegateTests();
+    });
+
+    describe("With Json web signature", () => {
+      beforeAll(() => {
+        createClaim = createJwtClaim;
+      });
+      delegateTests();
+    });
+
+    //   it("should reject the second DID authentication with first Claim issuer", async () => {
+    //     verifier = new AuthTokenVerifier(firstDocument);
+    //     const did = await verifier.verify(secondClaim);
+
+    //     assert.strictEqual(did, null);
+    //   });
+
+    //   it("should reject first DID with second Claim issuer", async () => {
+    //     verifier = new AuthTokenVerifier(secondDocument);
+    //     const did = await verifier.verify(firstClaim);
+
+    //     assert.strictEqual(did, null);
+    //   });
+
+    //   it("should authenticate second DID with second Claim issuer", async () => {
+    //     verifier = new AuthTokenVerifier(secondDocument);
+    //     const did = await verifier.verify(secondClaim);
+
+    //     assert.strictEqual(did, secondDID);
+    //   });
+  });
+});

--- a/test/TestDidDocuments.ts
+++ b/test/TestDidDocuments.ts
@@ -1,83 +1,36 @@
-import { Keys } from '@ew-did-registry/keys'
-import {IDIDDocument} from "@ew-did-registry/did-resolver-interface"
+import { Methods } from "@ew-did-registry/did";
+import {
+  IDIDDocument,
+  IPublicKey,
+  KeyTags,
+  PubKeyType,
+} from "@ew-did-registry/did-resolver-interface";
+import { Wallet, utils, BigNumber } from "ethers";
 
-export const firstKeys = new Keys();
-export const secondKeys = new Keys();
+const { computePublicKey } = utils;
 
-export const firstDocument : IDIDDocument = {
-    id: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3',
-    authentication: [
-      {
-        type: 'owner',
-        validity: [Object],
-        publicKey: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#owner'
-      }
-    ],
-    created: null,
-    delegates: null,
-    proof: null,
-    publicKey: [
-      {
-        id: 'did:ethr:0x72EFf9faB7876c4c1b6cAe426c121358431758F3#key-owner',
-        type: 'Secp256k1veriKey',
-        controller: '0x72EFf9faB7876c4c1b6cAe426c121358431758F3',
-        publicKeyHex: '0x' + firstKeys.publicKey
-      },
-      {
-        id: 'did:ethr:0x731ac21Aa72c1A6E15243AFBB34cA9CC073D419B#key-owner',
-        type: 'Secp256k1veriKey',
-        controller: '0x731ac21Aa72c1A6E15243AFBB34cA9CC073D419B',
-        publicKeyHex: '0x037cff69ef821172f5df74d3f9406679cc27aba2d96438211538deeb325c9d434d'
-      }
-    ],
-    updated: null,
-    '@context': 'https://www.w3.org/ns/did/v1',
-}
-
-export const secondDocument : IDIDDocument = {
-  id: 'did:ethr:0x0E46cbecF1742DdEb29BBC56F27ad236483443b7',
-  authentication: [
-    {
-      type: 'owner',
-      validity: [Object],
-      publicKey: 'did:ethr:0x0E46cbecF1742DdEb29BBC56F27ad236483443b7#owner'
-    }
-  ],
-  created: null,
-  delegates: null,
-  proof: null,
-  publicKey: [
-    {
-      id: 'did:ethr:0xA533557F26477b1fA7BFa76E6eD5467D9Bc9d633#809ea74d-50c8-451b-a7ce-2fe37b724e0d',
-      type: 'Secp256k1sigAuth',
-      controller: '0xA533557F26477b1fA7BFa76E6eD5467D9Bc9d633',
-      publicKeyHex: 'mynewkey'
-    },
-    {
-      id: 'did:ethr:0x0E46cbecF1742DdEb29BBC56F27ad236483443b7#key-owner',
-      type: 'Secp256k1veriKey',
-      controller: '0x0E46cbecF1742DdEb29BBC56F27ad236483443b7',
-      publicKeyHex: '0x' + secondKeys.publicKey
-    }
-  ],
-  updated: null,
-  '@context': 'https://www.w3.org/ns/did/v1',
-}
-
-export const emptyAuthenticationDocument : IDIDDocument = {
-  id: 'did:ethr:0x0E46cbecF1742DdEb29BBC56F27ad236483443b7',
-  authentication: [],
-  created: null,
-  delegates: null,
-  proof: null,
-  publicKey: [
-    {
-      id: 'did:ethr:0xA533557F26477b1fA7BFa76E6eD5467D9Bc9d633#809ea74d-50c8-451b-a7ce-2fe37b724e0d',
-      type: 'Secp256k1sigAuth',
-      controller: '0xA533557F26477b1fA7BFa76E6eD5467D9Bc9d633',
-      publicKeyHex: '0x' + secondKeys.publicKey
-    }
-  ],
-  updated: null,
-  '@context': 'https://www.w3.org/ns/did/v1',
-}
+export const mockDocument = (
+  identity: Wallet,
+  { withOwnerKey = true }: { withOwnerKey?: boolean } = {}
+): IDIDDocument => {
+  const did = `did:${Methods.Erc1056}:${identity.address}`;
+  const doc: IDIDDocument = {
+    id: did,
+    publicKey: [],
+    authentication: [],
+  } as IDIDDocument;
+  if (withOwnerKey) {
+    doc.authentication.push({
+      type: "owner",
+      validity: BigNumber.from(47),
+      publicKey: `${did}#owner`,
+    });
+    doc.publicKey.push({
+      id: `${did}#${KeyTags.OWNER}`,
+      type: PubKeyType.VerificationKey2018,
+      controller: did,
+      publicKeyHex: computePublicKey(identity.publicKey, true),
+    } as IPublicKey);
+  }
+  return doc as IDIDDocument;
+};


### PR DESCRIPTION
- [x] add test for empty DID Doc
- [x] restore code which recovers eth address as DID auth verification https://github.com/energywebfoundation/passport-did-auth/blob/be6370b1a642d53f88a44493d4d2e89c3f66f815/lib/utils.ts#L74