### PR TITLE
Fixing publishing from master branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,7 +23,6 @@ jobs:
       contents: write
       deployments: write
       packages: write
-      actions: write
   
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR resolves issues with publishing on the master branch of passport-did-auth using Github Actions.

Instead of using the default GITHUB_TOKEN on github action workflow, the fix uses a GH_TOKEN_CI token with write access on protected branches.

Since GITHUB_TOKEN had limited write access, it couldn't write on protected branch. I created GH_TOKEN_CI and set write access on it so that writing can be performed on protected branches 

see the thread [Here](https://github.community/t/how-to-push-to-protected-branches-in-a-github-action/16101/9)