### PR TITLE
Fix/pda 20/fix canary version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,10 +19,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: cancel-previous
-    permissions: 
-      contents: write
-      deployments: write
-      packages: write
   
     steps:
       - uses: actions/checkout@v2
@@ -37,7 +33,7 @@ jobs:
         run: |
           git config --global user.email ${{ secrets.GH_EMAIL }}
           git config --global user.name ${{ secrets.GH_USER }}
-          git remote set-url origin "https://${{ github.token }}@github.com/energywebfoundation/passport-did-auth.git" > /dev/null 2>&1
+          git remote set-url origin "https://${{ secrets.GH_ACTION_TOKEN }}@github.com/energywebfoundation/passport-did-auth.git" > /dev/null 2>&1
           git reset --hard
           git fetch -u origin master:master
           git fetch -u origin develop:develop
@@ -61,22 +57,21 @@ jobs:
         if: github.ref == 'refs/heads/develop'
         uses: codfish/semantic-release-action@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Deploy on master branch
         if: github.ref == 'refs/heads/master'
         uses: codfish/semantic-release-action@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Merge master branch into develop branch
-        if: github.ref == 'refs/heads/master'
         run: |
           git checkout develop
           git merge origin/master
           git push origin develop
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: cancel-previous
-  
     steps:
       - uses: actions/checkout@v2
         with:
@@ -67,11 +66,22 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Merge master branch into develop branch
+  sync_master_to_development_branch :
+    if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop'
+    runs-on: ubuntu-latest
+    needs: deploy
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: develop
+          token: ${{ secrets.GH_ACTION_TOKEN }}
+
+      - name: Merge master into develop branch
         run: |
-          git checkout develop
+          git config --global user.email ${{ secrets.GH_EMAIL }}
+          git config --global user.name ${{ secrets.GH_USER }}
           git merge origin/master
-          git push origin develop
+          git push origin development
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,6 +82,6 @@ jobs:
           git config --global user.email ${{ secrets.GH_EMAIL }}
           git config --global user.name ${{ secrets.GH_USER }}
           git merge origin/master
-          git push origin development
+          git push origin develop
         env:
           GITHUB_TOKEN: ${{ secrets.GH_ACTION_TOKEN }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -71,7 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
-      - name: Merge to master branch
+      - name: Merge master branch into develop branch
         if: github.ref == 'refs/heads/master'
         run: |
           git checkout develop

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -10,5 +10,14 @@
       "channel": "canary"
     }
   ],
-  "repositoryUrl": "git@github.com:energywebfoundation/passport-did-auth.git"
+  "repositoryUrl": "git@github.com:energywebfoundation/passport-did-auth.git",
+  "plugins": [
+    "@semantic-release/npm",
+    [
+        "@semantic-release/git",
+        {
+            "assets": ["package.json", "docs/CHANGELOG.md"]
+        }
+    ]
+  ]
 }


### PR DESCRIPTION
### Summary

|             |   |
|-------------|---|
| Description |  This PR targets canary version updates so that it stays one version ahead of latest. The purpose of the PR is to keep canary versions synchronized to release branch. Hence anytime a new release is published, merging back master to develop will set canary version to the next number. The fix follows a similar pattern than https://github.com/energywebfoundation/iam-client-lib/pull/159  |
| Jira issue  |  https://energyweb.atlassian.net/browse/PDA-20  |

#### Type of request
<!--- Please delete options that are not relevant. -->
- [x] Bug fix (non-breaking change which fixes an issue)

### List of Features

- Setting merging master into dev
- Setting Personal Access Token
