### PR TITLE
fix(cacheServerClient): destructure axios response in login

### DIFF
--- a/lib/cacheServerClient.ts
+++ b/lib/cacheServerClient.ts
@@ -77,12 +77,9 @@ export class CacheServerClient {
       ).toString("hex")}`;
       const sig = await this.signer.signMessage(arrayify(keccak256(msg)));
       const encodedSignature = base64url(sig);
-      const data = (await this.httpClient.post<{ identityToken: string }>(
-        "/login",
-        {
-          identityToken: `${encodedHeader}.${encodedPayload}.${encodedSignature}`,
-        }
-      )) as Partial<{ token: string }>;
+      const { data } = await this.httpClient.post<{ token: string }>("/login", {
+        identityToken: `${encodedHeader}.${encodedPayload}.${encodedSignature}`,
+      });
       this!.httpClient!.defaults!.headers!.common[
         "Authorization"
       ] = `Bearer ${data.token}`;


### PR DESCRIPTION
Not sure how it worked before.
But `data` is a property of AxiosResponse type which is returned from `post`. `token` isn't a direct property of the response.
This how it is in `iam-client-lib` as well: https://github.com/energywebfoundation/iam-client-lib/blob/788f863d99b73599983567e265a8a911e3f1261a/src/modules/cacheClient/cacheClient.service.ts#L64