### PR TITLE
fix(claimVerifier): temporarily disable signature verification

### DIFF
--- a/lib/ClaimVerifier.ts
+++ b/lib/ClaimVerifier.ts
@@ -45,13 +45,13 @@ export class ClaimVerifier {
    *
    * @param claim: role claim
    */
-  async verifyRole(claim: Required<OffchainClaim>): Promise<{
+  private async verifyRole(claim: Required<OffchainClaim>): Promise<{
     name: IRoleDefinition["roleName"];
     namespace: OffchainClaim["claimType"];
   } | null> {
-    if (!(await this.verifySignature(claim))) {
-      return null;
-    }
+    // if (!(await this.verifySignature(claim))) {
+    //   return null;
+    // }
 
     const role = await this.getRoleDefinition(claim.claimType);
     if (!role) {
@@ -71,7 +71,6 @@ export class ClaimVerifier {
         name: role.roleName,
         namespace: claim.claimType,
       };
-      return null;
     } else if (role.issuer?.issuerType === "Role" && role.issuer.roleName) {
       const issuerClaims = await this.getOffchainClaims(claim.iss);
       const issuerRoles = issuerClaims.map((claim) => claim.claimType);

--- a/test/ClaimVerifier.test.ts
+++ b/test/ClaimVerifier.test.ts
@@ -103,7 +103,8 @@ describe("ClaimVerifier", () => {
     assert.strictEqual(verifiedRoles.length, claimsWithoutIssField.length);
   });
 
-  it("should reject invalid DID-type claim", async () => {
+  // TODO: Reenable once signature verification is fixed, see https://energyweb.atlassian.net/browse/PDA-23
+  xit("should reject invalid DID-type claim", async () => {
     const verifier = new ClaimVerifier(
       invalidClaims,
       getRoleDefinition(user2DID, "DID"),


### PR DESCRIPTION
It does not work because cache-server DID documents do not contain an issued token

Example serviceEndpoint from `https://identitycache-dev.energyweb.org/v1/DID/did%3Aethr%3A0x186d7024B1eCE2F4EA302a8E87a4C16f8FF68349`
```
{
      "id": "c461a57f-874e-490a-b426-e1134a2be4d9",
      "iat": 1630915775945,
      "iss": "did:ethr:0x7dD4cF86e6f143300C4550220c4eD66690a655fc",
      "sub": "did:ethr:0x186d7024B1eCE2F4EA302a8E87a4C16f8FF68349",
      "hash": "6801b73606088ec8b1bfd29ce83fcf5edfe14b3cfffd006786d070bdffaa80c0",
      "fields": [
        {
          "key": "orgname",
          "value": "OKE"
        }
      ],
      "signer": "did:ethr:0x7dD4cF86e6f143300C4550220c4eD66690a655fc",
      "hashAlg": "SHA256",
      "claimType": "orgowner.roles.orgcreator.apps.testorg.iam.ewc",
      "serviceEndpoint": "QmbxRjEAx828oQocgJ7wziSwZqkCoSpuAkTJmMAhXq2x5K",
      "claimTypeVersion": 1
}
```