### PR TITLE
chore: update node to v16.10

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           token: ${{ secrets.GH_PUSH_TOKEN }}
       - uses: actions/setup-node@v2-beta
         with:
-          node-version: '14.17.0'
+          node-version: '16.10.0'
           registry-url: https://registry.npmjs.org/
 
       - name: Set npm credentials

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ where the `iss` is DID of the subject and `blockNumber` is block number (or heig
 ### Prerequisities
 
 ```
-npm version 6+
-nodejs version 10+
+npm version 7+
+nodejs version 16.10+
 ```
 
 ### Building the Passport Strategy


### PR DESCRIPTION
This PR updates node version for deploy workflow to `16.10.0`.