### PR TITLE
feat: pass cacheserverclient instance to resolvers

### DIFF
--- a/lib/RoleCredentialResolver.ts
+++ b/lib/RoleCredentialResolver.ts
@@ -33,8 +33,7 @@ export class RoleCredentialResolver implements CredentialResolver {
     provider: providers.Provider,
     registrySetting: RegistrySettings,
     didStore: DidStore,
-    privateKey?: string,
-    cacheServerUrl?: string
+    cacheServerClient?: CacheServerClient
   ) {
     this._ipfsStore = didStore;
     this._ipfsCredentialResolver = new IpfsCredentialResolver(
@@ -42,13 +41,8 @@ export class RoleCredentialResolver implements CredentialResolver {
       registrySetting,
       didStore
     );
-    if (privateKey && cacheServerUrl) {
-      this._cacheServerClient = new CacheServerClient({
-        privateKey,
-        provider,
-        url: cacheServerUrl,
-      });
-      this._cacheServerClient.login();
+    if (cacheServerClient) {
+      this._cacheServerClient = cacheServerClient;
     }
   }
 

--- a/lib/RoleIssuerResolver.ts
+++ b/lib/RoleIssuerResolver.ts
@@ -3,7 +3,7 @@ import {
   IIssuerDefinition,
 } from '@energyweb/credential-governance';
 import { IssuerResolver } from '@energyweb/vc-verification';
-import { providers, utils } from 'ethers';
+import { utils } from 'ethers';
 import { CacheServerClient } from './cacheServerClient';
 import { EthersProviderIssuerResolver } from '@energyweb/vc-verification';
 import { Logger } from './Logger';
@@ -17,20 +17,13 @@ export class RoleIssuerResolver implements IssuerResolver {
 
   constructor(
     domainReader: DomainReader,
-    provider?: providers.Provider,
-    userPrivateKey?: string,
-    cacheServerUrl?: string
+    cacheServerClient?: CacheServerClient
   ) {
     this._ethersProviderIssuerResolver = new EthersProviderIssuerResolver(
       domainReader
     );
-    if (userPrivateKey && cacheServerUrl && provider) {
-      this._cacheServerClient = new CacheServerClient({
-        privateKey: userPrivateKey,
-        provider,
-        url: cacheServerUrl,
-      });
-      this._cacheServerClient.login();
+    if (cacheServerClient) {
+      this._cacheServerClient = cacheServerClient;
     }
   }
 

--- a/lib/RoleRevokerResolver.ts
+++ b/lib/RoleRevokerResolver.ts
@@ -6,7 +6,7 @@ import {
   EthersProviderRevokerResolver,
   RevokerResolver,
 } from '@energyweb/vc-verification';
-import { providers, utils } from 'ethers';
+import { utils } from 'ethers';
 import { CacheServerClient } from './cacheServerClient';
 import { Logger } from './Logger';
 
@@ -19,20 +19,13 @@ export class RoleRevokerResolver implements RevokerResolver {
 
   constructor(
     domainReader: DomainReader,
-    provider?: providers.Provider,
-    userPrivateKey?: string,
-    cacheServerUrl?: string
+    cacheServerClient?: CacheServerClient
   ) {
     this._ethersProviderRevokerResolver = new EthersProviderRevokerResolver(
       domainReader
     );
-    if (userPrivateKey && cacheServerUrl && provider) {
-      this._cacheServerClient = new CacheServerClient({
-        privateKey: userPrivateKey,
-        provider,
-        url: cacheServerUrl,
-      });
-      this._cacheServerClient.login();
+    if (cacheServerClient) {
+      this._cacheServerClient = cacheServerClient;
     }
   }
 


### PR DESCRIPTION
This PR makes changes to use `cacheServerInstance` instead of initialising it in resolvers classes.